### PR TITLE
dpmt profile: Also check that pristine-tar is installed

### DIFF
--- a/profiles/dpmt/hooks/post
+++ b/profiles/dpmt/hooks/post
@@ -9,8 +9,10 @@ TARBALL=`find .. -maxdepth 1 -type f -name "${NAME}_${VERSION}.orig.tar.*" -prin
 
 # do nothing if .git directory exists
 test \! -d .git || exit 0
-# make sure git-dpm is installed
-test -x /usr/bin/git-dpm  || (echo 'E: please install git-dpm package' >&2; exit 1)
+# make sure git-dpm and pristine-tar areinstalled
+for dep in git-dpm pristine-tar; do
+  test -x "/usr/bin/$dep" || echo "E: please install $dep package"
+done | grep . >&2 && exit 1
 
 git init
 git remote add origin ssh://git.debian.org/git/python-modules/packages/${NAME}.git


### PR DESCRIPTION
Since the script uses pristine-tar later, ask for it to be installed up
front. If neither git-dpm nor pristine-tar are installed, ask for both at the
same time.