### PR TITLE
rules.tpl: run dh_auto_build -i before building Sphinx documentation

### DIFF
--- a/templates/debian/rules.tpl
+++ b/templates/debian/rules.tpl
@@ -8,6 +8,7 @@ export {{key}}={{value}}{% endfor %}
 {%- if docs and docs.sphinx_dir %}
 
 override_dh_auto_build-indep:
+	dh_auto_build -i
 ifeq (,$(filter nodoc,$(DEB_BUILD_OPTIONS)))
 	cd {{docs.sphinx_dir}} && \
 	PYTHONPATH=$(CURDIR) http_proxy='http://127.0.0.1:9/' https_proxy='https://127.0.0.1:9/' \


### PR DESCRIPTION
This was lost during commit f1167f50d86337f88e1bfa25dddd5c6c005224f1.