### PR TITLE
No clean and no check buildeps while building source package

### DIFF
--- a/py2dsp
+++ b/py2dsp
@@ -71,7 +71,7 @@ def main(args):
         dpath = unpack(fpath, args.root, dirname)
 
     yield from debianize(dpath, ctx, args.profile)
-    yield from execute(['dpkg-buildpackage', '-S', '-us', '-uc',
+    yield from execute(['dpkg-buildpackage', '-S', '-us', '-uc', '-nc', '-d',
                         '-I.git', '-i.git'], dpath)
     if args.build:
         yield from execute(['dpkg-buildpackage', '-b'], dpath)

--- a/pypi2debian
+++ b/pypi2debian
@@ -249,7 +249,7 @@ if __name__ == '__main__':
     commands = parser.add_argument_group('commands', 'override commands')
     commands.add_argument('--build-src-cmd', action='store', metavar='COMMAND',
                           help='command to build source package',
-                          default='dpkg-buildpackage -S -uc -us -I.git -i.git')
+                          default='dpkg-buildpackage -S -uc -us -nc -d -I.git -i.git')
     commands.add_argument('--build-cmd', action='store', metavar='COMMAND',
                           help='build command, none by default')
 


### PR DESCRIPTION
By default dpkg-buildpackage will run clean and check builddeps.
Both may fail if required build dependencies are not met (clean require dh-python).
This is not needed to build a source package only (-S).

In my usage I build the source package using py2dsp and then build the binary package using sbuild (which automatically install builddeps).