### PR TITLE
Define coroutine: fix cannot 'yield from' a coroutine object in a non-coroutine generator

### DIFF
--- a/pypi2deb/pypi.py
+++ b/pypi2deb/pypi.py
@@ -112,7 +112,7 @@ def parse_pkg_info(fpath):
     """Parse PKG-INFO file"""
     raise NotImplementedError()  # FIXME
 
-
+@asyncio.coroutine
 def download(name, version=None, destdir='.'):
     details = yield from get_pypi_info(name, version)
     if not details:


### PR DESCRIPTION
To my understanding, a coroutine object created with async def isn't a generator, so one can't actually yield from it in the usual way. Python 3.5+ requires coroutines to be defined with `async def` or `@asyncio.coroutine ` and will throw exceptions if one tries to pass anything that does not conform to this.

Fixes #16 
Tested the fix in Debian 9 with python 3.5 and aiohttp version 3.0.8

Links to documentation that I found useful:
- [Python asyncio](https://docs.python.org/3.5/library/asyncio-task.html)
- [Coroutines](http://book.pythontips.com/en/latest/coroutines.html)
- [Python: Generators, Coroutines, Native Coroutines and async/await](http://masnun.com/2015/11/13/python-generators-coroutines-native-coroutines-and-async-await.html)