### PR TITLE
Use new Python Package Index url, https://pypi.org

### DIFF
--- a/pypi2deb/pypi.py
+++ b/pypi2deb/pypi.py
@@ -30,8 +30,8 @@ import aiohttp
 from pypi2deb.decorators import cache
 from pypi2deb.tools import pkg_name, execute
 
-PYPI_JSON_URL = environ.get('PYPI_JSON_URL', 'https://pypi.python.org/pypi/')
-PYPI_XMLRPC_URL = environ.get('PYPI_XMLRPC_URL', 'https://pypi.python.org/pypi')
+PYPI_JSON_URL = environ.get('PYPI_JSON_URL', 'https://pypi.org/pypi')
+PYPI_XMLRPC_URL = environ.get('PYPI_XMLRPC_URL', 'https://pypi.org/pypi')
 log = logging.getLogger('pypi2deb')
 
 


### PR DESCRIPTION
A new version of Python Package Index has been deployed and
pypi.python.org has been deprecated in favor of pypi.org. Although
requests to the former url will get a HTTP 302 redirect, py2dsp
will try to decode HTML as JSON and will break.

This commit updates default values for PYPI_JSON_URL and
PYPI_XMLRPC_URL to the new one.