### PR TITLE
Revert "await for session.close()"

### DIFF
--- a/pypi2deb/pypi.py
+++ b/pypi2deb/pypi.py
@@ -55,8 +55,7 @@ def get_pypi_info(name, version=None):
             return
         return result
     finally:
-        if session is not None:
-            yield from session.close()
+        session is not None and session.close()
 
 
 def parse_pypi_info(data):
@@ -153,8 +152,7 @@ def download(name, version=None, destdir='.'):
             data = yield from response.read()
             fp.write(data)
     finally:
-        if session is not None:
-            yield from session.close()
+        session is not None and session.close()
 
     if orig_ext != ext:
         cmd = ['mk-origtargz', '--rename', '--compression', 'xz',


### PR DESCRIPTION
This reverts commit 5657c1b

The reverted commit introduced this regression:
```
$ ./py2dsp mako
E: py2dsp py2dsp:145: 'NoneType' object is not iterable
```