### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 pypi2deb (2.20180805) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Use secure copyright file specification URI.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 00:22:42 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pypi2deb (2.20180805) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 00:22:42 +0000
+
 pypi2deb (2.20180804) unstable; urgency=medium
 
   [ Oliver Okrongli ]

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/p1otr/pypi2deb
 
 Package: pypi2deb
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, 
+Depends: ${misc:Depends}, ${python3:Depends},
  build-essential,
  dh-python,
  devscripts,

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: pypi2deb
 Upstream-Contact: Piotr Ożarowski <piotr@debian.org>
 Source: https://github.com/p1otr/pypi2deb


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/pypi2deb/15e2603b-9172-46b8-9f1e-806159fccaee.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/15e2603b-9172-46b8-9f1e-806159fccaee/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/15e2603b-9172-46b8-9f1e-806159fccaee/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/15e2603b-9172-46b8-9f1e-806159fccaee/diffoscope)).
